### PR TITLE
Enable jpeg support in php gd extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN mkdir -p /etc/apt/keyrings \
 
 # Install MariaDB and Redis and PHP (incl Apache) and Cypress dependencies
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get install -y libpng-dev libzip-dev libicu-dev \
+    && apt-get install -y libpng-dev libzip-dev libicu-dev libjpeg62-turbo-dev \
     && docker-php-ext-install mysqli pdo pdo_mysql intl \
-    && docker-php-ext-configure gd \
+    && docker-php-ext-configure gd --with-jpeg \
     && docker-php-ext-install gd \
     && pecl install redis zip \
     && docker-php-ext-enable redis zip \


### PR DESCRIPTION
## Tasks

- [x] Add jpeg support so Drupal can generate image styles for jpeg files