### PR TITLE
Fix dotfiles install (#45) and upgrade to PHP 8.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/php:8.3
+FROM mcr.microsoft.com/devcontainers/php:8.4
 
 # Change default umask and add user to web group so we can share write permission on web files
 # Configure pam_umask to set umask to 002 (works regardless of /etc/login.defs content)

--- a/local/etc/uceap.d/devcontainer_on_create.sh
+++ b/local/etc/uceap.d/devcontainer_on_create.sh
@@ -1,4 +1,6 @@
 function devcontainer_on_create() {
+  _cwd_workspace
+
   # Change default umask and add user to web group so we can share write permission on web files
   sed -i 's/^#umask\s*022/umask 002/' ~/.profile
   echo "umask 002" >>~/.zshrc
@@ -91,6 +93,9 @@ function devcontainer_on_create() {
   if [ -x .devcontainer/onCreate.sh ]; then
     .devcontainer/onCreate.sh
   fi
+
+  # Leave the shellServer with a valid cwd for any subsequent step (see issue #45)
+  cd "$WORKSPACE_FOLDER"
 }
 
 _devcontainer_on_create_desc='runs when the devcontainer is created'

--- a/local/etc/uceap.d/devcontainer_post_create.sh
+++ b/local/etc/uceap.d/devcontainer_post_create.sh
@@ -1,4 +1,6 @@
 function devcontainer_post_create() {
+	_cwd_workspace
+
 	# set global ServerName so that apachectl isn't chatty
 	if [[ -n "$CODESPACE_NAME" ]]; then
 		SERVER_NAME="$CODESPACE_NAME-8080.app.github.dev"
@@ -27,6 +29,9 @@ function devcontainer_post_create() {
 	if [ -x .devcontainer/postCreate.sh ]; then
 		.devcontainer/postCreate.sh
 	fi
+
+	# Leave the shellServer with a valid cwd for any subsequent step (see issue #45)
+	cd "$WORKSPACE_FOLDER"
 }
 
 _devcontainer_post_create_desc='runs after the devcontainer is created'

--- a/local/etc/uceap.d/devcontainer_update_content.sh
+++ b/local/etc/uceap.d/devcontainer_update_content.sh
@@ -14,6 +14,9 @@ function devcontainer_update_content() {
 	if [ -x .devcontainer/updateContent.sh ]; then
 		.devcontainer/updateContent.sh
 	fi
+
+	# Leave the shellServer with a valid cwd for any subsequent step (see issue #45)
+	cd "$WORKSPACE_FOLDER"
 }
 
 _devcontainer_update_content_desc='runs when devcontainer content needs updating'


### PR DESCRIPTION
## Summary
- Fix #45: lifecycle scripts now anchor their cwd to `$WORKSPACE_FOLDER` on entry and exit, so the shellServer's cwd stays valid for the devcontainer CLI's dotfiles install step.
- Bump base image from `mcr.microsoft.com/devcontainers/php:8.3` to `:8.4`.

## Test plan
- [x] `dck && dce` with `--dotfiles-repository` set against a fresh container — dotfiles clone succeeds, no exit 128.
- [x] `~/.devcontainer/.dotfilesMarker` and `~/dotfiles/` both populated after first `devcontainer up`.
- [x] Container builds successfully on PHP 8.4 and Drupal app comes up (composer install, drush deploy, apache).
- [x] Spot-check that PHP extensions (mysqli, pdo_mysql, intl, gd, redis, zip) still load on 8.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)