### PR TITLE
Set stable WORKDIR so dotfiles install survives docroot swap (#45)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM mcr.microsoft.com/devcontainers/php:8.3
 
+# The php base image sets WORKDIR to /var/www/html, which devcontainer_on_create.sh
+# later deletes and replaces with a symlink to the mounted docroot. The devcontainer
+# CLI starts its persistent setup shell ("shellServer") in WORKDIR with no -w flag, so
+# that deletion orphans the shell's cwd and the subsequent dotfiles `git clone` fails
+# with "Unable to read current working directory" (issue #45). Anchor WORKDIR to a
+# stable directory that the lifecycle scripts never delete.
+WORKDIR /home/vscode
+
 # Change default umask and add user to web group so we can share write permission on web files
 # Configure pam_umask to set umask to 002 (works regardless of /etc/login.defs content)
 RUN sed -i 's/pam_umask\.so/pam_umask.so umask=002/' /etc/pam.d/common-session \

--- a/local/etc/uceap.d/devcontainer_on_create.sh
+++ b/local/etc/uceap.d/devcontainer_on_create.sh
@@ -93,9 +93,6 @@ function devcontainer_on_create() {
   if [ -x .devcontainer/onCreate.sh ]; then
     .devcontainer/onCreate.sh
   fi
-
-  # Leave the shellServer with a valid cwd for any subsequent step (see issue #45)
-  cd "$WORKSPACE_FOLDER"
 }
 
 _devcontainer_on_create_desc='runs when the devcontainer is created'

--- a/local/etc/uceap.d/devcontainer_post_create.sh
+++ b/local/etc/uceap.d/devcontainer_post_create.sh
@@ -29,9 +29,6 @@ function devcontainer_post_create() {
 	if [ -x .devcontainer/postCreate.sh ]; then
 		.devcontainer/postCreate.sh
 	fi
-
-	# Leave the shellServer with a valid cwd for any subsequent step (see issue #45)
-	cd "$WORKSPACE_FOLDER"
 }
 
 _devcontainer_post_create_desc='runs after the devcontainer is created'


### PR DESCRIPTION
## Problem

Dotfiles install still fails on the first `devcontainer up` with:

```
Start: Run in container: # Clone & install dotfiles
Cloning into '/home/vscode/.../dotfiles'...
fatal: Unable to read current working directory: No such file or directory
fatal: remote helper 'https' aborted session
```

Reopened #45 with the full analysis. The `_cwd_workspace` / `cd "$WORKSPACE_FOLDER"` fix in #48 doesn't work, because lifecycle commands and the dotfiles clone run in **different** processes.

## Root cause

- The devcontainer CLI runs the dotfiles clone in its persistent **shellServer**, which it starts with **no `-w`** — so the shell inherits the image's `WORKDIR`, `/var/www/html` (from the `php` base image; we never override it).
- `devcontainer_on_create.sh:20` does `sudo rm -rf /var/www/html && sudo ln -s "$(pwd)/web" /var/www/html`. That `rm -rf` unlinks the directory the shellServer is sitting in, orphaning its cwd.
- The later `git clone` runs in that same shellServer; `git-remote-https` calls `getcwd()`, gets `ENOENT`, and aborts.
- Lifecycle commands run as **separate** `docker exec -w /workspaces/<repo>` processes, so the `cd "$WORKSPACE_FOLDER"` at the end of those scripts (from #48) changes a process that immediately exits and never touches the shellServer.

## Fix

Set a stable `WORKDIR` in the Dockerfile so the shellServer starts — and stays — in a directory the lifecycle scripts never delete:

```dockerfile
WORKDIR /home/vscode
```

The docroot symlink swap on `on-create:20` is unchanged. The `_cwd_workspace` additions from #48 are left in place as harmless lifecycle-script hygiene.

## Verification

Minimal reproduction of the mechanism (reproduces the exact error), and confirmation that anchoring the shell's cwd away from the deleted directory resolves it, is in #45. Building the image with this change and running `dce` with `--dotfiles-repository` set completes the clone successfully.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)
