### PR TITLE
Set umask 002 system-wide instead of per-user shell rc files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,22 @@ FROM mcr.microsoft.com/devcontainers/php:8.3
 # stable directory that the lifecycle scripts never delete.
 WORKDIR /home/vscode
 
-# Change default umask and add user to web group so we can share write permission on web files
-# Configure pam_umask to set umask to 002 (works regardless of /etc/login.defs content)
+# Set umask to 002 system-wide so files stay group-writable for the www-data web
+# server. We can't rely on per-user shell rc files: developers often symlink their
+# own ~/.zshrc/~/.bashrc from a personal dotfiles repo, overwriting our edits. And
+# pam_umask only fires for login PAM sessions, which the VS Code-spawned terminals
+# and `exec`s in this devcontainer don't open. So set it in the system shell files:
+#   - /etc/zsh/zshenv        sourced by EVERY zsh invocation (login/non-login, interactive/not)
+#   - /etc/bash.bashrc       sourced by interactive non-login bash (VS Code terminals)
+#   - /etc/profile.d/umask.sh sourced by login shells (sh and bash)
+# Note: non-interactive bash (e.g. `bash -c`, scripts) has no equivalent hook, but
+# tooling such as drush runs under zsh, which /etc/zsh/zshenv covers completely.
+# pam_umask is left in place as a backstop for real PAM sessions (ssh, su, cron).
 RUN sed -i 's/pam_umask\.so/pam_umask.so umask=002/' /etc/pam.d/common-session \
-    && sed -i 's/pam_umask\.so/pam_umask.so umask=002/' /etc/pam.d/common-session-noninteractive
+    && sed -i 's/pam_umask\.so/pam_umask.so umask=002/' /etc/pam.d/common-session-noninteractive \
+    && echo "umask 002" >> /etc/zsh/zshenv \
+    && echo "umask 002" >> /etc/bash.bashrc \
+    && echo "umask 002" > /etc/profile.d/umask.sh
 RUN usermod -aG www-data vscode
 
 # Add glow for formatting command usage output (and because it's just nice)

--- a/local/etc/uceap.d/devcontainer_on_create.sh
+++ b/local/etc/uceap.d/devcontainer_on_create.sh
@@ -1,13 +1,11 @@
 function devcontainer_on_create() {
   _cwd_workspace
 
-  # Change default umask and add user to web group so we can share write permission on web files
-  sed -i 's/^#umask\s*022/umask 002/' ~/.profile
-  echo "umask 002" >>~/.zshrc
-  echo "umask 002" >>~/.bashrc
-
-	# the first time we run this script the default umask is still in effect,
-	# which messes up permissions on the log file that gets created when we run drush deploy
+	# umask is configured system-wide in the Dockerfile (/etc/zsh/zshenv,
+	# /etc/bash.bashrc and /etc/profile.d/umask.sh) so files we create stay
+	# group-writable for the www-data web server. That isn't in effect yet in this
+	# shell on the first run, which would leave the log file created by the drush
+	# deploy below non-group-writable, so set it here too.
 	umask 002
 
   sudo sh -c "cat >> /etc/apache2/sites-available/000-default.conf" <<-EOF


### PR DESCRIPTION
## Problem

Drush (run by tooling) writes `private://logs/debug-*.log` as `644` owned by `vscode:www-data`, so the apache `www-data` web server can't append to them → pages 500 (notably `/user/login`, which breaks Cypress in a `before all` hook).

## Why the per-user approach was fragile

The previous setup appended `umask 002` to per-user shell rc files (`~/.zshrc`, `~/.bashrc`) and relied on `pam_umask`. Two things defeat that in this devcontainer:

- **No PAM session.** VS Code-spawned terminals and `exec`s don't open a PAM session, so `pam_umask` never fires for them — that's why the shell-rc appends existed in the first place.
- **Personal dotfiles shadowing.** Developers commonly symlink `~/.zshrc` / `~/.bashrc` from a personal dotfiles repo (e.g. applied after `onCreate`), which overwrites our per-user edits. The umask line silently disappears.

## Change: set it system-wide

System shell files are immune to both problems, so set `umask 002` there instead:

| File | Covers |
|---|---|
| `/etc/zsh/zshenv` | **Every** zsh invocation — login/non-login, interactive/not. Covers the drush/tooling path. |
| `/etc/bash.bashrc` | Interactive non-login bash (VS Code terminals) |
| `/etc/profile.d/umask.sh` | Login shells (sh and bash) |

The per-user appends in `devcontainer_on_create` are **dropped as redundant**. Only the in-process `umask 002` is kept, because the system-wide config isn't in effect in that shell on the very first run (before the log file that `drush deploy` creates). `pam_umask` is kept as a backstop for real PAM sessions (ssh, su, cron).

### Caveat (not a regression)

Non-interactive bash (`bash -c`, `#!/bin/bash` scripts) has no equivalent hook — bash has nothing like `zshenv`. This matches the previous behavior (`~/.bashrc` only covers interactive bash too), and the actual tooling path runs under zsh, which `/etc/zsh/zshenv` covers completely.

## Verification

Reproduced in a running container with `~/.zshrc` symlinked to a personal dotfiles repo: non-login zsh ran at `022` and drush wrote `644` logs. With `umask 002` reaching the shell, interactive zsh and drush run at `002` and drush-created log files come out `664` (`vscode:www-data`), which the web server can append to. `/etc/bash.bashrc` confirmed sourced by interactive non-login bash, and `/etc/profile.d/*.sh` sourced by `/etc/profile`, on the `mcr.microsoft.com/devcontainers/php:8.3` base image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)