### PR TITLE
Update xdebug  port on vscode config

### DIFF
--- a/local/share/vscode/launch.json
+++ b/local/share/vscode/launch.json
@@ -5,7 +5,7 @@
       "name": "Listen for Xdebug",
       "type": "php",
       "request": "launch",
-      "port": 9000
+      "port": 9003
     }
   ]
 }


### PR DESCRIPTION
This pull request updates the Xdebug configuration in the `launch.json` file to use the correct port.

* Debugging configuration:
  * `microsoft/devcontainers/php:8.3` ships with xdebug3 which listens to port 9003
  * Changed the Xdebug listening port from `9000` to `9003` in `local/share/vscode/launch.json`, aligning with the default port for Xdebug 3.