### PR TITLE
Allow triggering the Docker build manually

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,15 @@ on:
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]
+  # Rebuild on demand, e.g. to pick up a security update without waiting for the
+  # weekly schedule. Select the branch to build in the "Run workflow" dialog; the
+  # image is tagged after that branch, same as a push to it.
+  workflow_dispatch:
+    inputs:
+      no_cache:
+        description: 'Build without cache (pulls fresh base image and re-runs package installs)'
+        type: boolean
+        default: false
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -84,6 +93,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # A cached build would happily reuse the vulnerable layers a security
+          # rebuild is meant to replace, so let the operator opt out of the cache.
+          no-cache: ${{ inputs.no_cache == true }}
+          pull: ${{ inputs.no_cache == true }}
 
       # Sign the resulting Docker image digest.
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
Closes #50

Adds `workflow_dispatch` to the Docker workflow so the image can be rebuilt on demand — for a security update, or just to republish without pushing an empty commit.

### Behavior

- **Picking the ref.** The "Run workflow" dialog lets you choose the branch. `type=ref,event=branch` in the metadata step covers `workflow_dispatch`, so a manual run on `main` publishes `ghcr.io/uceap/devcontainer-drupal:main` exactly like a push does — that's the tag downstream projects consume, so this covers @shaundrong's case of wanting the real image instead of a branch image.
- **`no_cache` input.** `cache-from: type=gha` would otherwise replay the cached base image and `apt-get` layers, which is precisely what a security rebuild is meant to discard. Checking the box sets `no-cache` and `pull` on the build step so the base image is re-pulled and package installs re-run.

Defaults to `false`, and `inputs.no_cache` is empty outside `workflow_dispatch`, so `== true` renders as literal `false` — scheduled, push, and PR builds are unchanged.

### Testing

- YAML parses; all four triggers and both expressions resolve as intended.
- `actionlint` is clean on the changed lines.
- Merging this makes the trigger available on `main`; a manual run with **Build without cache** checked is the real end-to-end check.

### Left alone

`actionlint` flags two pre-existing issues this PR doesn't touch — `actions/checkout@v3` is on a runner GitHub no longer supports, and the cosign step has an unquoted `${DIGEST}` (SC2086). Happy to fix either here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)