### PR TITLE
Upgrade base image to devcontainers/php:8.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/php:8.3
+FROM mcr.microsoft.com/devcontainers/php:8.4
 
 # The php base image sets WORKDIR to /var/www/html, which devcontainer_on_create.sh
 # later deletes and replaces with a symlink to the mounted docroot. The devcontainer


### PR DESCRIPTION
Swaps the base image from `mcr.microsoft.com/devcontainers/php:8.3` to `:8.4`. That is the only line that changes — nothing else in the repo referenced the PHP version.

---

**DO NOT MERGE** until _all_ Drupal sites are ready for PHP 8.4.

---

## Why

Pantheon runs PHP 8.4 (UCDCW-158 for ucdcweb2, UP-1921 for myeap2), but this image still built on 8.3. That gap is a real liability rather than cosmetic drift:

- Local dev **and** CI both run this image, so both were on 8.3.
- Pantheon does not process `php_version` changes on multidevs, so PR environments stay on the old version too.

The result is that **no part of the pipeline could surface a PHP 8.4 deprecation** — which is exactly how the myeap2 8.4 deprecations reached TEST unnoticed. UCDCW-158 had to be verified out-of-band by running `php -l` across ~22.5k files inside a throwaway `php:8.4-cli` container, because there was no environment available that actually ran 8.4.

## Why this should be a low-risk swap

| | 8.3 tag | 8.4 tag |
|---|---|---|
| PHP | 8.3.32 | **8.4.23** |
| Base OS | Debian 13 (trixie) | Debian 13 (trixie) |
| Xdebug | bundled | bundled |

8.4.23 is the same patch release Pantheon's 8.4 runtime is on (confirmed via `drush status` against Pantheon dev). Same Debian release means the `apt-get install` list is unaffected, and the `docker-php-ext-install` / `pecl install` steps (mysqli, pdo_mysql, intl, gd, redis, zip) all resolve against the base image's PHP rather than a pinned version.

## Testing

- Verified `mcr.microsoft.com/devcontainers/php:8.4` exists and reports PHP 8.4.23 on Debian 13 trixie with Xdebug loaded.
- A local `linux/amd64` build of this Dockerfile was run to validate the extension and apt steps against the new base.
- CI here builds `linux/amd64,linux/arm64` and publishes a `pr-<N>` tag; ucdcweb2's `.devcontainer/docker-compose.yml` will be pointed at that tag for hands-on local testing on 8.4 before this merges.

## Rollout note

Because `docker-compose.yml` in the consuming repos tracks `:main`, merging this changes the PHP version for **every** project using this image — ucdcweb2 and myeap2 both. Both are on 8.4 on Pantheon, so this brings local dev into line rather than ahead. Worth a heads-up to the team that a container rebuild is needed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)