### PR TITLE
Point developers to devcontainer-reset-db in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,13 @@ To see a list of available commands, run `uceap` in the terminal. You can also r
 
 I frequently invoke `uceap devcontainer-reset-db` to reset my local database after switching branches, or after e2e tests have left data behind. It recreates the mariadb container from the seed data baked into its image and then runs `drush deploy`, so there's nothing to download from Pantheon. With shell completions installed, it's `uce<TAB>devc<TAB>r<TAB>`.
 
-> 👉 When working on a PR that adds update hooks or makes config changes, it's generally a good idea to make sure it applies cleanly to a database matching the QA environment. To do this, switch to the `qa` branch, reset the database, switch back to your branch, and run the deploy command (e.g. `drush md` for the portal):
+> 👉 When working on a PR that adds update hooks or makes config changes, it's generally a good idea to make sure it applies cleanly to a database matching the deployed environments. Pass `--skip-deploy` so the reset leaves the database at its seed state, then run the deploy command yourself (e.g. `drush md` for the portal) to see how it behaves against that database:
 > ``` zsh
-> git checkout qa
-> composer install
-> uceap devcontainer-reset-db
-> git checkout -
+> uceap devcontainer-reset-db --skip-deploy
 > composer install
 > drush deploy
 > ```
+> Without `--skip-deploy`, the reset runs `drush deploy` for you, which applies your branch's updates before you get a chance to watch them.
 
 The seed data baked into the database image is a point-in-time snapshot of the DEV environment, and it doesn't include the files directory. When you need the _current_ contents of DEV, along with its files, use `uceap refresh-content` instead: it runs `composer install`, compiles the theme, and invokes `db-rebuild.sh` with the latest database and files backups from Pantheon.
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ To see a list of available commands, run `uceap` in the terminal. You can also r
 
 I frequently invoke `uceap devcontainer-reset-db` to reset my local database after switching branches, or after e2e tests have left data behind. It recreates the mariadb container from the seed data baked into its image and then runs `drush deploy`, so there's nothing to download from Pantheon. With shell completions installed, it's `uce<TAB>devc<TAB>r<TAB>`.
 
-> 👉 When working on a PR that adds update hooks or makes config changes, it's generally a good idea to make sure it applies cleanly to a database matching the deployed environments. Pass `--skip-deploy` so the reset leaves the database at its seed state, then run the deploy command yourself (e.g. `drush md` for the portal) to see how it behaves against that database:
+> 👉 When working on a PR that adds update hooks or makes config changes, it's generally a good idea to make sure it applies cleanly to a database matching the QA environment. To do this, switch to the `qa` branch, reset the database, switch back to your branch, and run the deploy command (e.g. `drush md` for the portal):
 > ``` zsh
-> uceap devcontainer-reset-db --skip-deploy
+> git checkout qa
+> composer install
+> uceap devcontainer-reset-db
+> git checkout -
 > composer install
 > drush deploy
 > ```
-> Without `--skip-deploy`, the reset runs `drush deploy` for you, which applies your branch's updates before you get a chance to watch them.
 
 The seed data baked into the database image is a point-in-time snapshot of the DEV environment, and it doesn't include the files directory. When you need the _current_ contents of DEV, along with its files, use `uceap refresh-content` instead: it runs `composer install`, compiles the theme, and invokes `db-rebuild.sh` with the latest database and files backups from Pantheon.
 

--- a/README.md
+++ b/README.md
@@ -15,16 +15,19 @@ To see a list of available commands, run `uceap` in the terminal. You can also r
 
 ## Tips and tricks
 
-I frequently invoke `uceap refresh-content` to reset my local environment after switching branches. It runs `composer install` and invokes `db-rebuild.sh` with a fresh copy of the latest snapshot of the dev environment database and files. With shell completions installed, it's as easy as `uce<TAB>r<TAB>`.
+I frequently invoke `uceap devcontainer-reset-db` to reset my local database after switching branches, or after e2e tests have left data behind. It recreates the mariadb container from the seed data baked into its image and then runs `drush deploy`, so there's nothing to download from Pantheon. With shell completions installed, it's `uce<TAB>devc<TAB>r<TAB>`.
 
-> 👉 When working on a PR that adds update hooks or makes config changes, it's generally a good idea to make sure it applies cleanly to a database matching the QA environment. To do this, switch to the `qa` branch, run refresh-content, switch back to your branch, and run the deploy command (e.g. `drush md` for the portal):
+> 👉 When working on a PR that adds update hooks or makes config changes, it's generally a good idea to make sure it applies cleanly to a database matching the QA environment. To do this, switch to the `qa` branch, reset the database, switch back to your branch, and run the deploy command (e.g. `drush md` for the portal):
 > ``` zsh
 > git checkout qa
-> uceap refresh-content
+> composer install
+> uceap devcontainer-reset-db
 > git checkout -
 > composer install
 > drush deploy
 > ```
+
+The seed data baked into the database image is a point-in-time snapshot of the DEV environment, and it doesn't include the files directory. When you need the _current_ contents of DEV, along with its files, use `uceap refresh-content` instead: it runs `composer install`, compiles the theme, and invokes `db-rebuild.sh` with the latest database and files backups from Pantheon.
 
 Troubleshooting an issue on the live site? `TERMINUS_ENV=live uceap refresh-content` will pull the latest backup of the database and files from LIVE. _You'll be knee-deep in PII in no time!_ **Be sure to reset your database and files with DEV data as soon as you're done.**
 


### PR DESCRIPTION
## Summary

Updates the **Tips and tricks** section to lead with `uceap devcontainer-reset-db` instead of `uceap refresh-content`.

- Lead recommendation is now `devcontainer-reset-db`: it recreates the mariadb container from the seed data baked into its image and runs `drush deploy`, with no Pantheon download.
- The update-hook / config-change recipe uses `devcontainer-reset-db`, with `composer install` added before it — unlike `refresh-content`, reset-db doesn't install dependencies, and its trailing `drush deploy` runs against whatever code is checked out.
- Added a paragraph on when `refresh-content` is still the right tool: the baked seed data is a point-in-time DEV snapshot and excludes `web/sites/default/files`.
- Kept the `TERMINUS_ENV=live uceap refresh-content` tip unchanged — reset-db can't pull LIVE data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)